### PR TITLE
Build players.json from tournaments.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -166,7 +166,7 @@ module.exports = function(grunt) {
     players = _.mapObject(players, function(player) {
       return {
         id: player.id,
-        player: player.name,
+        name: player.name,
         tournaments: _.sortBy(player.tournaments, function(tournament) {
           var date = tournaments[tournament.tid].date;
           var year = date.substr(-4);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,7 +161,23 @@ module.exports = function(grunt) {
           money: standing.money
         });
       })
-    })
+    });
+
+    players = _.mapObject(players, function(player) {
+      return {
+        id: player.id,
+        player: player.name,
+        tournaments: _.sortBy(player.tournaments, function(tournament) {
+          var date = tournaments[tournament.tid].date;
+          var year = date.substr(-4);
+          var month = date.match(/\w+/)[0].substr(0, 3);
+          var day = date.match(/\d+/)[0];
+          var test = Date.parse(month + ' ' + day + ', ' + year);
+
+          return - test;
+        })
+      };
+    });
 
     players = JSON.stringify(players, null, 4);
     players = players.replace(/[\u007F-\uFFFF]/g, function(chr) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,10 +163,6 @@ module.exports = function(grunt) {
       })
     })
 
-    players = _.sortBy(players, function(player) {
-      return player.id;
-    })
-
     players = JSON.stringify(players, null, 4);
     players = players.replace(/[\u007F-\uFFFF]/g, function(chr) {
       return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt-jsxhint": "^0.5.0",
     "grunt-react": "^0.10.0",
     "grunt-shell": "^1.1.1",
-    "react-tools": "^0.12.2"
+    "react-tools": "^0.12.2",
+    "underscore": "^1.8.3"
   },
   "dependencies": {
     "accounting": "^0.4.1",


### PR DESCRIPTION
I built a grunt tasks that creates `players.json` from `tournaments.json`. 

```
grunt players
```

It's not elegant, but does the trick as far as I can tell. 

NB: I currently overwrite the `players.json` in `data`.