### PR TITLE
Libsass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
     sass: {
       all: {
         options: {
-          style: 'compressed'
+          outputStyle: 'compressed'
         },
         files: {
           'build/css/app.css': 'src/css/app.scss'
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-jsxhint');
   grunt.loadNpmTasks('grunt-shell');

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "grunt-browserify": "^3.4.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-gh-pages": "^1.0.0",
     "grunt-jsxhint": "^0.5.0",
     "grunt-react": "^0.10.0",
+    "grunt-sass": "^1.2.0",
     "grunt-shell": "^1.1.1",
     "react-tools": "^0.12.2",
     "underscore": "^1.8.3"


### PR DESCRIPTION
@czarandy 

I switched from grunt-contrib-sass to grunt-sass. 
grunt-sass ist faster, fully compatible and we could get rid of the project's ruby dependency.  
Build is running without errors. 