### PR TITLE
Simplify recent tournament view

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -29,68 +29,35 @@
   border: 0;
 }
 
+.List {
+  margin-left: 0;
+  padding-left: 0;
+  list-style-type: none;
+}
+
+.List-index {
+  margin-right: 5px;
+}
+
+.List-item--big {
+  font-size: 1.5em;
+  margin-left: -5px;
+}
+
+.List-item--big .List-link {
+  margin-left: -4px;
+}
+
 .recentTournamentWrapper {
   .recentTournament {
-    display: flex;
-    justify-content: space-between;
-
-    .topfour {
-      list-style-type: none;
-      width: 50%;
-
-      li > span {
-        margin-right: 5px;
-      }
-    }
-
-    .topfour li:nth-child(1),
-    .topfour li:nth-child(2),
-    .topfour li:nth-child(3) {
-      font-size: 1.5em;
-      margin-left: -5px;
-
-      a {
-        margin-left: -4px;
-      }
-    }
-
-    .topfour.topfour2hg li:nth-child(3) {
-      font-size: inherit;
-      margin-left: inherit;
-      a {
-        margin-left: inherit;
-      }
-    }
-
-    .topeight {
-      list-style-type: none;
-      width: 50%;
-
-      li > span {
-        margin-right: 5px;
-      }
-    }
-
-    .topeight li:first-child {
-      font-size: 1.5em;
-      margin-left: -5px;
-
-      a {
-        margin-left: -4px;
-      }
-    }
-
     .image {
-      display: flex;
-      flex-direction: column;
-      width: 40%;
       img {
         max-height: 80px;
-        max-width: 100%
+        max-width: 100%;
+        margin-bottom: 10px;
       }
     }
   }
-
 }
 
 .standingsTable {

--- a/src/js/app.react.js
+++ b/src/js/app.react.js
@@ -283,32 +283,42 @@ var RecentTournaments = React.createClass({
                   </Link>
                 </div>
                 <div className="panel-body recentTournament">
-                  <div className="image">
-                    {that._renderLogo(id, tournament)}
-                    {tournament.formats.join(' / ')}
-                    {tournament.date}
-                    {tournament.location}
+                  <div className="row">
+                    <div className="col-sm-5">
+                      <div className="image">
+                        {that._renderLogo(id, tournament)}
+                        <p>
+                          {tournament.formats.join(' / ')}
+                          <br />
+                          {tournament.date}
+                          <br />
+                          {tournament.location}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="col-sm-7">
+                      <ul className="List">
+                        {
+                          _.map(tournament.top, function(player, idx) {
+                            if (tournament.team2hg) {
+                              idx = (idx / 2) | 0;
+                            }
+                            else if (tournament.team) {
+                              idx = (idx / 3) | 0;
+                            }
+                            return (
+                              <li className={idx === 0 ? 'List-item List-item--big' : 'List-item '} key={player.id}>
+                                <span className="List-index">{idx + 1}{'. '}</span>
+                                <Link className="List-link" to="player" params={{id: player.id}}>
+                                  {player.name}
+                                </Link>
+                              </li>
+                            );
+                          })
+                        }
+                      </ul>
+                    </div>
                   </div>
-                  <ul className={tournament.team ? (tournament.team2hg ? 'topfour topfour2hg' : 'topfour') : 'topeight'}>
-                    {
-                      _.map(tournament.top, function(player, idx) {
-                        if (tournament.team2hg) {
-                          idx = (idx / 2) | 0;
-                        }
-                        else if (tournament.team) {
-                          idx = (idx / 3) | 0;
-                        }
-                        return (
-                          <li key={player.id}>
-                            <span>{idx + 1}{'. '}</span>
-                            <Link to="player" params={{id: player.id}}>
-                              {player.name}
-                            </Link>
-                          </li>
-                        );
-                      })
-                    }
-                  </ul>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
* Use bootstrap responsive grid.
* Displays linear on small devices.
* Use List with big modifier.
* Remove nested styles based on content and nth:child.