### PR TITLE
Display player stats linear on mobile (#66)

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -24,21 +24,35 @@
   }
 }
 
-.statsWrapper {
-  padding: 10px;
+/*
+ * Stat
+ */
+
+.Stat {
   text-align: center;
+}
 
-  .alert {
+.Stat-alert {
+  margin-bottom: 0;
+}
+
+.Stat-value {
+  font-weight: bold;
+}
+
+.Stat-link {
+  color: #fff !important;
+}
+
+@media (min-width: 768px) {
+  .Stat {
+    padding: 10px;
+  }
+
+  .Stat-alert {
     display: inline-block;
-    margin: 0 5px;
-  }
-
-  .statsValue {
-    font-weight: bold;
-  }
-
-  a {
-    color: #fff;
+    margin-right: 5px;
+    margin-left: 5px;
   }
 }
 
@@ -54,6 +68,10 @@
   width: 16px;
   height: 16px;
 }
+
+/*
+ * List
+ */
 
 .List {
   margin-left: 0;

--- a/src/js/Player.react.js
+++ b/src/js/Player.react.js
@@ -23,37 +23,37 @@ const Player = props => {
       <div className="page-header pageHeader">
         <h1><PlayerLink player={player} /></h1>
       </div>
-      <div className="statsWrapper">
-        <div className="alert alert-info" >
-          <div className="statsValue">
+      <div className="Stat">
+        <div className="Stat-alert alert alert-info">
+          <div className="Stat-value">
             {player.stats.t1} / {player.stats.t8} / {player.stats.t16} / {player.stats.total}
           </div>
           <div>
-            <Link to="/rankings/t1">Wins</Link>
+            <Link className="Stat-link" to="/rankings/t1">Wins</Link>
             {' / '}
-            <Link to="/rankings/t8">T8</Link>
+            <Link className="Stat-link" to="/rankings/t8">T8</Link>
             {' / '}
-            <Link to="/rankings/t16">T16</Link>
+            <Link className="Stat-link" to="/rankings/t16">T16</Link>
             {' / '}
-            <Link to="/rankings/total">Total</Link>
+            <Link className="Stat-link" to="/rankings/total">Total</Link>
           </div>
         </div>
-        <div className="alert alert-info" >
-          <div className="statsValue">
+        <div className="Stat-alert alert alert-info" >
+          <div className="Stat-value">
             {player.getMoney()}
           </div>
           <div>
-            <Link to="/rankings/money">
+            <Link className="Stat-link" to="/rankings/money">
               Total Money
             </Link>
           </div>
         </div>
-        <div className="alert alert-info" >
-          <div className="statsValue">
+        <div className="Stat-alert alert alert-info" >
+          <div className="Stat-value">
             {player.stats.points}
           </div>
           <div>
-            <Link to="rankings/points">
+            <Link className="Stat-link" to="rankings/points">
               Total Pro Points
             </Link>
           </div>


### PR DESCRIPTION
Just a minor improvement. 

Before:

<img width="366" alt="screen shot 2016-07-24 at 21 01 00" src="https://cloud.githubusercontent.com/assets/19599753/17085824/3707b194-51e2-11e6-8c59-93644039edac.png">

After: 

<img width="360" alt="screen shot 2016-07-24 at 21 01 12" src="https://cloud.githubusercontent.com/assets/19599753/17085829/474a8fa4-51e2-11e6-9826-7a0f751d07c8.png">

