### PR TITLE
Added Worlds

### DIFF
--- a/players-championship-2012.json
+++ b/players-championship-2012.json
@@ -1,0 +1,79 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "August 29-31, 2012",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "players-championship",
+    "location": "Seattle, Washington, United States",
+    "logo": "ptlogo.png",
+    "name": "Magic Players Championship",
+    "standings": [
+        {
+            "money": 40000,
+            "name": "Yuuya Watanabe"
+        },
+        {
+            "money": 20000,
+            "name": "Shota Yasooka"
+        },
+        {
+            "money": 10000,
+            "name": "Paulo Vitor Damo da Rosa"
+        },
+        {
+            "money": 10000,
+            "name": "Jon Finkel"
+        },
+        {
+            "money": 5000,
+            "name": "Shuhei Nakamura"
+        },
+        {
+            "money": 5000,
+            "name": "Brian Kibler"
+        },
+        {
+            "money": 5000,
+            "name": "Samuele Estratti"
+        },
+        {
+            "money": 5000,
+            "name": "Alexander Hayne"
+        },
+        {
+            "money": 1000,
+            "name": "Martin Juza"
+        },
+        {
+            "money": 1000,
+            "name": "Owen Turtenwald"
+        },
+        {
+            "money": 1000,
+            "name": "Jun'ya Iyanaga"
+        },
+        {
+            "money": 1000,
+            "name": "Luis Scott-Vargas"
+        },
+        {
+            "money": 1000,
+            "name": "Josh Utter-Leyton"
+        },
+        {
+            "money": 1000,
+            "name": "David Ochoa"
+        },
+        {
+            "money": 1000,
+            "name": "Tzu Ching Kuo"
+        },
+        {
+            "money": 1000,
+            "name": "Reid Duke"
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}

--- a/world-championships-2013.json
+++ b/world-championships-2013.json
@@ -1,0 +1,95 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "July 31-August 1 & 4, 2013",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "world-championships-2013",
+    "location": "Amsterdam, The Netherlands",
+    "logo": "ptlogo.png",
+    "name": "World Championships",
+    "standings": [
+        {
+            "money": 40000,
+            "name": "Shahar Shenhar",
+            "propoints": 12
+        },
+        {
+            "money": 20000,
+            "name": "Reid Duke",
+            "propoints": 11
+        },
+        {
+            "money": 10000,
+            "name": "Ben Stark",
+            "propoints": 9
+        },
+        {
+            "money": 10000,
+            "name": "Josh Utter-Leyton",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Craig Wescoe",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Yuuya Watanabe",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Brian Kibler",
+            "propoints": 6
+        },
+        {
+            "money": 5000,
+            "name": "Shuhei Nakamura",
+            "propoints": 6
+        },
+        {
+            "money": 1000,
+            "name": "Dmitriy Butakov",
+            "propoints": 6
+        },
+        {
+            "money": 1000,
+            "name": "David Ochoa",
+            "propoints": 6
+        },
+        {
+            "money": 1000,
+            "name": "Stanislav Cifka",
+            "propoints": 5
+        },
+        {
+            "money": 1000,
+            "name": "Tom Martell",
+            "propoints": 5
+        },
+        {
+            "money": 1000,
+            "name": "Willy Edel",
+            "propoints": 5
+        },
+        {
+            "money": 1000,
+            "name": "Eric Froehlich",
+            "propoints": 4
+        },
+        {
+            "money": 1000,
+            "name": "Lee Shi Tian",
+            "propoints": 3
+        },
+        {
+            "money": 1000,
+            "name": "Martin Juza",
+            "propoints": 2
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}

--- a/world-championships-2014.json
+++ b/world-championships-2014.json
@@ -1,0 +1,135 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "December 2-3 & 7, 2014",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "world-championships-2014",
+    "location": "Nice, France",
+    "logo": "ptlogo.png",
+    "name": "World Championships",
+    "standings": [
+        {
+            "money": 50000,
+            "name": "Shahar Shenhar",
+            "propoints": 13
+        },
+        {
+            "money": 20000,
+            "name": "Patrick Chapin",
+            "propoints": 12
+        },
+        {
+            "money": 10000,
+            "name": "Yuuya Watanabe",
+            "propoints": 10
+        },
+        {
+            "money": 10000,
+            "name": "Kentaro Yamamoto",
+            "propoints": 9
+        },
+        {
+            "money": 5000,
+            "name": "Shaun McLaren",
+            "propoints": 9
+        },
+        {
+            "money": 5000,
+            "name": "Yuuki Ichikawa",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Ivan Floch",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "William Jensen",
+            "propoints": 8
+        },
+        {
+            "money": 3000,
+            "name": "Samuel Black",
+            "propoints": 8
+        },
+        {
+            "money": 3000,
+            "name": "Lars Dam",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Josh Utter-Leyton",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Paul Rietzl",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Owen Turtenwald",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Reid Duke",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Stanislav Cifka",
+            "propoints": 6
+        },
+        {
+            "money": 3000,
+            "name": "Tom Martell",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Raphael Levy",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Jeremy Dezani",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Jacob Wilson",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Willy Edel",
+            "propoints": 5
+        },
+        {
+            "money": 2000,
+            "name": "Sung Wook Nam",
+            "propoints": 5
+        },
+        {
+            "money": 2000,
+            "name": "Raymond Perez",
+            "propoints": 5
+        },
+        {
+            "money": 2000,
+            "name": "Paulo Vitor Damo da Rosa",
+            "propoints": 4
+        },
+        {
+            "money": 2000,
+            "name": "Lee Shi Tian",
+            "propoints": 4
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}

--- a/world-championships-2015.json
+++ b/world-championships-2015.json
@@ -1,0 +1,135 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "August 28-30, 2015",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "world-championships-2015",
+    "location": "Seattle, Washington, United States",
+    "logo": "ptlogo.png",
+    "name": "World Championships",
+    "standings": [
+        {
+            "money": 50000,
+            "name": "Seth Manfield",
+            "propoints": 17
+        },
+        {
+            "money": 20000,
+            "name": "Owen Turtenwald",
+            "propoints": 11
+        },
+        {
+            "money": 10000,
+            "name": "Paul Rietzl",
+            "propoints": 9
+        },
+        {
+            "money": 10000,
+            "name": "Samuel Black",
+            "propoints": 9
+        },
+        {
+            "money": 5000,
+            "name": "Magnus Lantto",
+            "propoints": 9
+        },
+        {
+            "money": 5000,
+            "name": "Martin Muller",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Shaun McLaren",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Thiago Saporito",
+            "propoints": 8
+        },
+        {
+            "money": 3000,
+            "name": "Ondrey Strasky",
+            "propoints": 8
+        },
+        {
+            "money": 3000,
+            "name": "Yuuya Watanabe",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Paulo Vitor Damo da Rosa",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Jacob Wilson",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Joel Larsson",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Alexander Hayne",
+            "propoints": 7
+        },
+        {
+            "money": 3000,
+            "name": "Martin Dang",
+            "propoints": 6
+        },
+        {
+            "money": 3000,
+            "name": "Steve Rubin",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Kentaro Yamamoto",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Mike Sigrist",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Eric Froehlich",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Lee Shi Tian",
+            "propoints": 6
+        },
+        {
+            "money": 2000,
+            "name": "Brad Nelson",
+            "propoints": 5
+        },
+        {
+            "money": 2000,
+            "name": "Antonion Del Moral Leon",
+            "propoints": 5
+        },
+        {
+            "money": 2000,
+            "name": "Shahar Shenhar",
+            "propoints": 4
+        },
+        {
+            "money": 2000,
+            "name": "Ari Lax",
+            "propoints": 2
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}

--- a/world-championships-2016.json
+++ b/world-championships-2016.json
@@ -1,0 +1,135 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "September 1-4, 2016",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "world-championships-2016",
+    "location": "Seattle, Washington, United States",
+    "logo": "ptlogo.png",
+    "name": "World Championships",
+    "standings": [
+        {
+            "money": 70000,
+            "name": "Brian Braun-Duin",
+            "propoints": 14
+        },
+        {
+            "money": 40000,
+            "name": "Marcio Carvalho",
+            "propoints": 11
+        },
+        {
+            "money": 20000,
+            "name": "Oliver Tiu",
+            "propoints": 9
+        },
+        {
+            "money": 20000,
+            "name": "Shota Yasooka",
+            "propoints": 9
+        },
+        {
+            "money": 10000,
+            "name": "Lukas Blohon",
+            "propoints": 9
+        },
+        {
+            "money": 10000,
+            "name": "Luis Scott-Vargas",
+            "propoints": 9
+        },
+        {
+            "money": 10000,
+            "name": "Jiachen Tao",
+            "propoints": 8
+        },
+        {
+            "money": 10000,
+            "name": "Seth Manfield",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Thiago Saporito",
+            "propoints": 8
+        },
+        {
+            "money": 5000,
+            "name": "Steve Rubin",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Mike Sigrist",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Reid Duke",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Brad Nelson",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Joel Larsson",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Paulo Vitor Damo da Rosa",
+            "propoints": 7
+        },
+        {
+            "money": 5000,
+            "name": "Yuuya Watanabe",
+            "propoints": 6
+        },
+        {
+            "money": 2500,
+            "name": "Owen Turtenwald",
+            "propoints": 6
+        },
+        {
+            "money": 2500,
+            "name": "Ondrey Strasky",
+            "propoints": 6
+        },
+        {
+            "money": 2500,
+            "name": "Samuel Pardee",
+            "propoints": 5
+        },
+        {
+            "money": 2500,
+            "name": "Andrea Mengucci",
+            "propoints": 5
+        },
+        {
+            "money": 2500,
+            "name": "Niels Noorlander",
+            "propoints": 5
+        },
+        {
+            "money": 2500,
+            "name": "Kazuyuki Takimura",
+            "propoints": 5
+        },
+        {
+            "money": 2500,
+            "name": "Ryoichi Tamada",
+            "propoints": 4
+        },
+        {
+            "money": 2500,
+            "name": "Martin Muller",
+            "propoints": 3
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}

--- a/world-championships-2017.json
+++ b/world-championships-2017.json
@@ -1,0 +1,135 @@
+{
+    "coverage": "http://magic.wizards.com/en/events/coverage/ptatl96",
+    "date": "October 6-8, 2017",
+    "formats": [
+        "Sealed"
+    ],
+    "id": "world-championships-2017",
+    "location": "Boston, Massachusetts, United States",
+    "logo": "ptlogo.png",
+    "name": "World Championships",
+    "standings": [
+        {
+            "money": 100000,
+            "name": "William Jensen",
+            "propoints": 13
+        },
+        {
+            "money": 50000,
+            "name": "Javier Dominguez",
+            "propoints": 8
+        },
+        {
+            "money": 25000,
+            "name": "Josh Utter-Leyton",
+            "propoints": 6
+        },
+        {
+            "money": 25000,
+            "name": "Kelvin Chew",
+            "propoints": 6
+        },
+        {
+            "money": 10000,
+            "name": "Reid Duke",
+            "propoints": 6
+        },
+        {
+            "money": 10000,
+            "name": "Samuel Black",
+            "propoints": 5
+        },
+        {
+            "money": 10000,
+            "name": "Seth Manfield",
+            "propoints": 5
+        },
+        {
+            "money": 10000,
+            "name": "Owen Turtenwald",
+            "propoints": 5
+        },
+        {
+            "money": 5000,
+            "name": "Gerry Thompson",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Shota Yasooka",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Christian Calcano",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Paulo Vitor Damo da Rosa",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Eric Froehlich",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Sebastian Pozzo",
+            "propoints": 4
+        },
+        {
+            "money": 5000,
+            "name": "Brad Nelson",
+            "propoints": 3
+        },
+        {
+            "money": 5000,
+            "name": "Martin Juza",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Ken Yukuhiro",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Yuuya Watanabe",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Marcio Carvalho",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Lee Shi Tian",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Martin Muller",
+            "propoints": 3
+        },
+        {
+            "money": 2500,
+            "name": "Donald Smith",
+            "propoints": 2
+        },
+        {
+            "money": 2500,
+            "name": "Lucas Esper Berhoud",
+            "propoints": 1
+        },
+        {
+            "money": 2500,
+            "name": "Samuel Pardee",
+            "propoints": 0
+        }
+    ],
+    "team": false,
+    "team2hg": false
+}


### PR DESCRIPTION
Hi Andi!

I added the Worlds tournaments. They are currently in the main directory, where they don't belong I think. As I am always a bit frightened of doing something stupid that causes you extra overhead I left it at that. (the update has actually been finished for more than a week, but unwittingly I did a pull request to myself...) Anyway, the tournaments should be functional. Would be cool if you could add an 'other tournaments' section to the main page. It should probably be constructed exactly as the 'current' page, only with the tournaments from the subdirectory. I will add some other tournaments later, but I am a little busy with tournament preparation right now.